### PR TITLE
Feature/rm4pro

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,35 @@
   <div id="app">
     <div class="container">
       <h1>Generate Home Assistant configuration for Livolo RF switches used via Broadlink RM 2/RM Pro/RM Plus remote</h1>
+      <div class="row">
+        <div class="col-lg-4">
+          <div class="input-group mb-3">
+            <div class="input-group-prepend">
+              <span class="input-group-text" id="entity-id">Entity Id</span>
+            </div>
+            <input type="text" class="form-control" aria-describedby="entity-id" v-model="options.entity_id">
+          </div>      
+        </div>
+        <div class="col-lg-6">
+          <div class="input-group mb-3">
+            <div class="input-group mb-3">
+              <div class="input-group-prepend mr-3">
+                <span class="input-group-text" id="entity-id">Broadlink model</span>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio1" value="rmpro" v-model="options.remote_model"
+                v-on:change="selectRemoteModel">
+                <label class="form-check-label" for="inlineRadio1">RM 2/RM Pro/RM Plus</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio2" value="rm4pro" v-model="options.remote_model"
+                v-on:change="selectRemoteModel">
+                <label class="form-check-label" for="inlineRadio2">RM4 Pro</label>
+              </div>
+            </div>
+          </div>      
+        </div>      
+      </div>
       <ul class="nav nav-tabs">
         <li class="nav-item">
           <a class="nav-link" :class="{active: step==1}" href="javascript:void(0)" v-on:click="switchStep(1)">
@@ -20,7 +49,7 @@
         </li>
       </ul>
       <Switches v-model="switches" v-if="step==1"></Switches>
-      <HAConfig v-model="switches" v-show="step==2"></HAConfig>
+      <HAConfig v-model="switches" v-show="step==2" v-bind:options="options"></HAConfig>
       <Pairing v-model="switches" v-if="step==3"></Pairing>
       <Advanced v-if="step==4" v-on:reloadStorage="reloadStorage"></Advanced>
     </div>
@@ -55,7 +84,11 @@ export default {
   data: function() {
     return {
       switches: [],
-      step: 1
+      step: 1,
+      options: {
+        entity_id: "remote.broadlink_remote",
+        remote_model: "rmpro"
+      }
     };
   },
   methods: {
@@ -64,6 +97,12 @@ export default {
     },
     reloadStorage() {
       this.step = 1;
+    },
+    selectRemoteModel() {
+      if (this.options.remote_model === "rmpro") 
+        this.options.entity_id = "remote.broadlink_remote";
+      else if (this.options.remote_model === "rm4pro")
+        this.options.entity_id = "remote.broadlink_rm4_pro_remote";
     }
   }
 };

--- a/src/broadlink.js
+++ b/src/broadlink.js
@@ -42,7 +42,7 @@ class Broadlink {
     const header = "b2" + repeats.toString(16) + "260013";
     const id_bin = this.id.toString(2).padStart(16, '0');
     const btn_bin = button.toString(2).padStart(7, '0');
-    var id_btn_bin = id_bin.concat(btn_bin);    
+    var id_btn_bin = id_bin.concat(btn_bin);
 
     id_btn_bin = id_btn_bin.replace(/0/g, "0606");
     id_btn_bin = id_btn_bin.replace(/1/g, "0c");
@@ -74,15 +74,12 @@ class Broadlink {
     return this.hexToBase64(hex_out);
   }
 
-
   hexToBase64(hexstring) {
     return btoa(hexstring.match(/\w{2}/g).map(function (a) {
       return String.fromCharCode(parseInt(a, 16));
     }).join(""));
   }
 }
-
-
 
 Broadlink.buttons = {
   btn1: 0,

--- a/src/broadlink.js
+++ b/src/broadlink.js
@@ -26,7 +26,16 @@ class Broadlink {
     return startId;
   }
 
-  getButtonCode(button, repeats = 200) {
+  getButtonCode(button, remoteModel, repeats = 200) {
+    if (remoteModel == "rmpro")
+      return this.getButtonCodeRmPro(button, repeats);
+    else if (remoteModel == "rm4pro")
+      return this.getButtonCodeRm4Pro(button, repeats);
+    else
+      throw "code generation for remote model " + remoteModel + " not supported!";
+  }
+
+  getButtonCodeRmPro(button, repeats = 200) {
     if(repeats < 50 || repeats > 255) {
       repeats = 200;
     }

--- a/src/broadlink.js
+++ b/src/broadlink.js
@@ -33,7 +33,7 @@ class Broadlink {
     const header = "b2" + repeats.toString(16) + "260013";
     const id_bin = this.id.toString(2).padStart(16, '0');
     const btn_bin = button.toString(2).padStart(7, '0');
-    var id_btn_bin = id_bin.concat(btn_bin);
+    var id_btn_bin = id_bin.concat(btn_bin);    
 
     id_btn_bin = id_btn_bin.replace(/0/g, "0606");
     id_btn_bin = id_btn_bin.replace(/1/g, "0c");
@@ -45,12 +45,35 @@ class Broadlink {
     return this.hexToBase64(hex_out);
   }
 
+  getButtonCodeRm4Pro(button, repeats = 200) {
+    if(repeats < 50 || repeats > 255) {
+      repeats = 200;
+    }
+    const header = "b2" + repeats.toString(16) + "b004009f06002004"; // header for rm4pro
+    const id_bin = this.id.toString(2).padStart(16, '0');
+    const btn_bin = button.toString(2).padStart(7, '0');
+    var id_btn_bin = id_bin.concat(btn_bin);
+
+    id_btn_bin = id_btn_bin.replace(/0/g, "0606");
+    id_btn_bin = id_btn_bin.replace(/1/g, "0c");
+    id_btn_bin = "13" + id_btn_bin;
+
+    var hex_out = header + id_btn_bin.repeat(15);
+    const pad_len = 32 - (hex_out.length - 24) % 32;
+
+    hex_out = hex_out + ('').padStart(pad_len, '0');
+    return this.hexToBase64(hex_out);
+  }
+
+
   hexToBase64(hexstring) {
     return btoa(hexstring.match(/\w{2}/g).map(function (a) {
       return String.fromCharCode(parseInt(a, 16));
     }).join(""));
   }
 }
+
+
 
 Broadlink.buttons = {
   btn1: 0,

--- a/src/components/HAConfig.vue
+++ b/src/components/HAConfig.vue
@@ -61,7 +61,7 @@ const secret = {
 YAML.defaultOptions.customTags = [secret];
 
 export default {
-  props: ["value"],
+  props: ["value", "options"],
   data: function() {
     return {
     };
@@ -115,9 +115,9 @@ switch:
           const id = sw.names[i].toLowerCase().replace(/[^a-z0-9]/g, "_");
           var togglePacket;
           if(sw.dimmer == true) {
-            togglePacket = remote.getButtonCode(Broadlink.buttons.btn1, 128);
+            togglePacket = remote.getButtonCodeRm4Pro(Broadlink.buttons.btn1, 128);
           } else {
-            togglePacket = remote.getButtonCode(Broadlink.buttons.btn10, 128);
+            togglePacket = remote.getButtonCodeRm4Pro(Broadlink.buttons.btn10, 128);
           }
           lights[id] = {
             friendly_name: sw.names[i],
@@ -136,7 +136,7 @@ switch:
               {
                 service: "remote.send_command",
                 target: {
-                  entity_id: "remote.broadlink_remote",
+                  entity_id: this.options.entity_id,
                 },
                 data: {
                   command: "b64:" + togglePacket
@@ -156,10 +156,10 @@ switch:
               {
                 service: "remote.send_command",
                 target: {
-                  entity_id: "remote.broadlink_remote",
+                  entity_id: this.options.entity_id,
                 },
                 data: {
-                  command: "b64:" + remote.getButtonCode(Broadlink.buttons.scn1)
+                  command: "b64:" + remote.getButtonCodeRm4Pro(Broadlink.buttons.scn1)
                 }
               },
               {
@@ -176,10 +176,10 @@ switch:
               {
                 service: "remote.send_command",
                 target: {
-                  entity_id: "remote.broadlink_remote",
+                  entity_id: this.options.entity_id,
                 },
                 data: {
-                  command: "b64:" + remote.getButtonCode(Broadlink.buttons.scn2)
+                  command: "b64:" + remote.getButtonCodeRm4Pro(Broadlink.buttons.scn2)
                 }
               },
               {
@@ -198,10 +198,10 @@ switch:
                 {
                   service: "remote.send_command",
                   target: {
-                    entity_id: "remote.broadlink_remote",
+                    entity_id: this.options.entity_id,
                   },
                   data: {
-                    command: "b64:" + remote.getButtonCode(Broadlink.buttons.dimToggle, 128)
+                    command: "b64:" + remote.getButtonCodeRm4Pro(Broadlink.buttons.dimToggle, 128)
                   }
                 },
                 {
@@ -218,10 +218,10 @@ switch:
                 {
                   service: "remote.send_command",
                   target: {
-                    entity_id: "remote.broadlink_remote",
+                    entity_id: this.options.entity_id,
                   },
                   data: {
-                    command: "b64:" + remote.getButtonCode(Broadlink.buttons.dimUp, 64)
+                    command: "b64:" + remote.getButtonCodeRm4Pro(Broadlink.buttons.dimUp, 64)
                   }
                 },
                 {
@@ -238,10 +238,10 @@ switch:
                 {
                   service: "remote.send_command",
                   target: {
-                    entity_id: "remote.broadlink_remote",
+                    entity_id: this.options.entity_id,
                   },
                   data: {
-                    command: "b64:" + remote.getButtonCode(Broadlink.buttons.dimDown, 64)
+                    command: "b64:" + remote.getButtonCodeRm4Pro(Broadlink.buttons.dimDown, 64)
                   }
                 }
               ]

--- a/src/components/HAConfig.vue
+++ b/src/components/HAConfig.vue
@@ -115,9 +115,9 @@ switch:
           const id = sw.names[i].toLowerCase().replace(/[^a-z0-9]/g, "_");
           var togglePacket;
           if(sw.dimmer == true) {
-            togglePacket = remote.getButtonCodeRm4Pro(Broadlink.buttons.btn1, 128);
+            togglePacket = remote.getButtonCode(Broadlink.buttons.btn1, this.options.remote_model, 128);
           } else {
-            togglePacket = remote.getButtonCodeRm4Pro(Broadlink.buttons.btn10, 128);
+            togglePacket = remote.getButtonCode(Broadlink.buttons.btn10, this.options.remote_model, 128);
           }
           lights[id] = {
             friendly_name: sw.names[i],
@@ -159,7 +159,7 @@ switch:
                   entity_id: this.options.entity_id,
                 },
                 data: {
-                  command: "b64:" + remote.getButtonCodeRm4Pro(Broadlink.buttons.scn1)
+                  command: "b64:" + remote.getButtonCode(Broadlink.buttons.scn1, this.options.remote_model)
                 }
               },
               {
@@ -179,7 +179,7 @@ switch:
                   entity_id: this.options.entity_id,
                 },
                 data: {
-                  command: "b64:" + remote.getButtonCodeRm4Pro(Broadlink.buttons.scn2)
+                  command: "b64:" + remote.getButtonCode(Broadlink.buttons.scn2, this.options.remote_model)
                 }
               },
               {
@@ -201,7 +201,7 @@ switch:
                     entity_id: this.options.entity_id,
                   },
                   data: {
-                    command: "b64:" + remote.getButtonCodeRm4Pro(Broadlink.buttons.dimToggle, 128)
+                    command: "b64:" + remote.getButtonCode(Broadlink.buttons.dimToggle, this.options.remote_model, 128)
                   }
                 },
                 {
@@ -221,7 +221,7 @@ switch:
                     entity_id: this.options.entity_id,
                   },
                   data: {
-                    command: "b64:" + remote.getButtonCodeRm4Pro(Broadlink.buttons.dimUp, 64)
+                    command: "b64:" + remote.getButtonCode(Broadlink.buttons.dimUp, this.options.remote_model, 64)
                   }
                 },
                 {
@@ -241,7 +241,7 @@ switch:
                     entity_id: this.options.entity_id,
                   },
                   data: {
-                    command: "b64:" + remote.getButtonCodeRm4Pro(Broadlink.buttons.dimDown, 64)
+                    command: "b64:" + remote.getButtonCode(Broadlink.buttons.dimDown, this.options.remote_model, 64)
                   }
                 }
               ]


### PR DESCRIPTION
Added support for the newer Broadlink RM4Pro devices.
- Will allow the user to pick either the rm4pro model or the older familiy. 
- Also, the entity_id is now editable (for rm4pro it has a different name anyway).

The changes are based on the discussion in this thread https://community.home-assistant.io/t/broadlink-rm-pro-livolo-switches-rf-learning-woes/12432, specifically the "rules" desribed by Adrian in this post:
https://community.home-assistant.io/t/broadlink-rm-pro-livolo-switches-rf-learning-woes/12432/152?u=bftanase

![image](https://user-images.githubusercontent.com/1143666/145692238-32515cb3-4218-40c4-9019-e019dda6958d.png)
